### PR TITLE
Duplicate floating ips are getting created

### DIFF
--- a/src/config/api-server/tests/test_ip_alloc.py
+++ b/src/config/api-server/tests/test_ip_alloc.py
@@ -313,7 +313,44 @@ class TestIpAlloc(test_case.ApiServerTestCase):
         self._vnc_lib.domain_delete(id=domain.uuid)
     #end
 
+    def test_notify_doesnt_persist(self):
+        # net/ip notify context shouldn't persist to db, should only
+        # update in-memory book-keeping
+        def_ipam = NetworkIpam()
+        ipam_obj = self._vnc_lib.network_ipam_read(
+                      fq_name=def_ipam.get_fq_name())
+        vn_obj = VirtualNetwork('vn-%s' %(self.id()))
+        ipam_sn_v4 = IpamSubnetType(subnet=SubnetType('11.1.1.0', 24))
+        vn_obj.add_network_ipam(ipam_obj, VnSubnetsType([ipam_sn_v4]))
+        self._vnc_lib.virtual_network_create(vn_obj)
 
+        iip_obj = InstanceIp('iip-%s' %(self.id()))
+        iip_obj.add_virtual_network(vn_obj)
+
+        class SpyCreateNode(object):
+            def __init__(self, orig_object, method_name):
+                self._orig_method = getattr(orig_object, method_name)
+                self._invoked = 0
+            # end __init__
+
+            def __call__(self, *args, **kwargs):
+                if self._invoked >= 1:
+                    raise Exception(
+                        "Instance IP was persisted more than once")
+
+                if args[0].startswith('/api-server/subnets'):
+                    self._invoked += 1
+                return self._orig_method(args, kwargs)
+        # end SpyCreateNode
+
+        orig_object = self._api_server._db_conn._zk_db._zk_client
+        method_name = 'create_node'
+        with test_common.patch(orig_object, method_name,
+                               SpyCreateNode(orig_object, method_name)):
+            self._vnc_lib.instance_ip_create(iip_obj)
+            self.assertTill(self.ifmap_has_ident, obj=iip_obj)
+
+    #end test_notify_doesnt_persist
 
 #end class TestIpAlloc
 

--- a/src/config/api-server/vnc_addr_mgmt.py
+++ b/src/config/api-server/vnc_addr_mgmt.py
@@ -169,7 +169,8 @@ class Subnet(object):
                  gw=None, service_address=None, enable_dhcp=True,
                  dns_nameservers=None,
                  alloc_pool_list=None,
-                 addr_from_start=False):
+                 addr_from_start=False,
+                 should_persist=True):
 
         network = IPNetwork('%s/%s' % (prefix, prefix_len))
 
@@ -243,11 +244,15 @@ class Subnet(object):
             if alloc_int['start'] <= int(service_node_address) <= alloc_int['end']:
                 exclude.append(service_node_address)
         self._db_conn.subnet_create_allocator(name, alloc_int_list,
-                                              addr_from_start)
+                                              addr_from_start,
+                                              should_persist=should_persist)
 
         # reserve excluded addresses
         for addr in exclude:
-            self._db_conn.subnet_alloc_req(name, int(addr))
+            if should_persist:
+                self._db_conn.subnet_reserve_req(name, int(addr), 'system-reserved')
+            else:
+                self._db_conn.subnet_set_in_use(name, int(addr))
 
         self._name = name
         self._network = network
@@ -274,19 +279,43 @@ class Subnet(object):
         return self._exclude
     # end get_exclude
 
+    # ip address management helper routines.
+    # ip_set/reset_in_use do not persist to DB just internal bitmap maintenance
+    # (for e.g. for notify context)
+    # ip_reserve/alloc/free persist to DB
     def is_ip_allocated(self, ipaddr):
         ip = IPAddress(ipaddr)
         addr = int(ip)
         return self._db_conn.subnet_is_addr_allocated(self._name, addr)
     # end is_ip_allocated
 
-    def ip_alloc(self, ipaddr=None):
-        req = None
+    def ip_set_in_use(self, ipaddr):
+        ip = IPAddress(ipaddr)
+        addr = int(ip)
+        return self._db_conn.subnet_set_in_use(self._name, addr)
+    # end ip_set_in_use
+
+    def ip_reset_in_use(self, ipaddr):
+        ip = IPAddress(ipaddr)
+        addr = int(ip)
+        return self._db_conn.subnet_reset_in_use(self._name, addr)
+    # end ip_reset_in_use
+
+    def ip_reserve(self, ipaddr, value):
+        ip = IPAddress(ipaddr)
+        req = int(ip)
+
+        addr = self._db_conn.subnet_reserve_req(self._name, req, value)
+        if addr:
+            return str(IPAddress(addr))
+        return None
+    # end ip_reserve
+
+    def ip_alloc(self, ipaddr=None, value=None):
         if ipaddr:
-            ip = IPAddress(ipaddr)
-            req = int(ip)
+            return self.ip_reserve(ipaddr, value)
     
-        addr = self._db_conn.subnet_alloc_req(self._name, req)
+        addr = self._db_conn.subnet_alloc_req(self._name, value)
         if addr:
             return str(IPAddress(addr))
         return None
@@ -388,7 +417,7 @@ class AddrMgmt(object):
         return subnet_dicts
     # end _get_subnet_dicts
 
-    def _create_subnet_objs(self, vn_fq_name_str, vn_dict):
+    def _create_subnet_objs(self, vn_fq_name_str, vn_dict, should_persist):
         self._subnet_objs[vn_fq_name_str] = {}
         # create subnet for each new subnet
         refs = vn_dict.get('network_ipam_refs', None)
@@ -415,7 +444,8 @@ class AddrMgmt(object):
                         enable_dhcp=dhcp_config,
                         dns_nameservers=nameservers,
                         alloc_pool_list=allocation_pools,
-                        addr_from_start=addr_start)
+                        addr_from_start=addr_start,
+                        should_persist=should_persist)
                     self._subnet_objs[vn_fq_name_str][subnet_name] = \
                          subnet_obj
                     ipam_subnet['default_gateway'] = str(subnet_obj.gw_ip)
@@ -430,7 +460,7 @@ class AddrMgmt(object):
         self._get_db_conn()
         vn_fq_name_str = ':'.join(obj_dict['fq_name'])
 
-        self._create_subnet_objs(vn_fq_name_str, obj_dict)
+        self._create_subnet_objs(vn_fq_name_str, obj_dict, should_persist=True)
     # end net_create_req
 
     def net_create_notify(self, obj_ids, obj_dict):
@@ -450,7 +480,7 @@ class AddrMgmt(object):
 
         vn_dict = result
         vn_fq_name_str = ':'.join(vn_dict['fq_name'])
-        self._create_subnet_objs(vn_fq_name_str, vn_dict)
+        self._create_subnet_objs(vn_fq_name_str, vn_dict, should_persist=False)
     # end net_create_notify
 
     def net_update_req(self, vn_fq_name, db_vn_dict, req_vn_dict, obj_uuid=None):
@@ -491,7 +521,7 @@ class AddrMgmt(object):
                     if cmp(req_alloc_list[index], db_alloc_list[index]):
                         raise AddrMgmtSubnetInvalid(vn_fq_name_str, key)
 
-        self._create_subnet_objs(vn_fq_name_str, req_vn_dict)
+        self._create_subnet_objs(vn_fq_name_str, req_vn_dict, should_persist=True)
     # end net_update_req
 
     def net_update_notify(self, obj_ids):
@@ -511,7 +541,7 @@ class AddrMgmt(object):
 
         vn_dict = result
         vn_fq_name_str = ':'.join(vn_dict['fq_name'])
-        self._create_subnet_objs(vn_fq_name_str, vn_dict)
+        self._create_subnet_objs(vn_fq_name_str, vn_dict, should_persist=False)
     # end net_update_notify
 
     # purge all subnets associated with a virtual network
@@ -755,7 +785,7 @@ class AddrMgmt(object):
     # allocate an IP address for given virtual network
     # we use the first available subnet unless provided
     def ip_alloc_req(self, vn_fq_name, vn_dict=None, sub=None, asked_ip_addr=None, 
-                     asked_ip_version=4):
+                     asked_ip_version=4, alloc_id=None):
         vn_fq_name_str = ':'.join(vn_fq_name)
         subnet_dicts = self._get_subnet_dicts(vn_fq_name, vn_dict)
 
@@ -787,7 +817,8 @@ class AddrMgmt(object):
                                     enable_dhcp=subnet_dict['enable_dhcp'],
                                     dns_nameservers=subnet_dict['dns_nameservers'],
                                     alloc_pool_list=subnet_dict['allocation_pools'],
-                                    addr_from_start = subnet_dict['addr_start'])
+                                    addr_from_start = subnet_dict['addr_start'],
+                                    should_persist=False)
                 self._subnet_objs[vn_fq_name_str][subnet_name] = subnet_obj
 
             if asked_ip_version != subnet_obj.get_version():
@@ -798,10 +829,21 @@ class AddrMgmt(object):
                 return asked_ip_addr
             if asked_ip_addr and not subnet_obj.ip_belongs(asked_ip_addr):
                 continue
+
+            # if user requests ip-addr and that can't be reserved due to
+            # existing object(iip/fip) using it, return an exception with
+            # the info. client can determine if its error or not
+            if asked_ip_addr:
+                return subnet_obj.ip_reserve(ipaddr=asked_ip_addr,
+                                             value=alloc_id)
+
             try:
-                ip_addr = subnet_obj.ip_alloc(ipaddr=asked_ip_addr)
+                ip_addr = subnet_obj.ip_alloc(ipaddr=None,
+                                              value=alloc_id)
             except Exception as e:
                 # ignore exception if it not a last subnet
+                self.config_log("Error: %s in ip_alloc_req" %(str(e)),
+                                level=SandeshLevel.SYS_ERR)
                 if current_count < subnet_count:
                     continue
                 else:
@@ -835,13 +877,14 @@ class AddrMgmt(object):
                                     enable_dhcp=subnet_dict['enable_dhcp'],
                                     dns_nameservers=subnet_dict['dns_nameservers'],
                                     alloc_pool_list=subnet_dict['allocation_pools'],
-                                    addr_from_start = subnet_dict['addr_start'])
+                                    addr_from_start = subnet_dict['addr_start'],
+                                    should_persist=False)
                 self._subnet_objs[vn_fq_name_str][subnet_name] = subnet_obj
 
             if not subnet_obj.ip_belongs(ip_addr):
                 continue
 
-            ip_addr = subnet_obj.ip_alloc(ipaddr=ip_addr)
+            ip_addr = subnet_obj.ip_set_in_use(ipaddr=ip_addr)
             break
     # end ip_alloc_notify
 
@@ -871,7 +914,8 @@ class AddrMgmt(object):
                                     enable_dhcp=subnet_dict['enable_dhcp'],
                                     dns_nameservers=subnet_dict['dns_nameservers'],
                                     alloc_pool_list=subnet_dict['allocation_pools'],
-                                    addr_from_start = subnet_dict['addr_start'])
+                                    addr_from_start = subnet_dict['addr_start'],
+                                    should_persist=False)
                 self._subnet_objs[vn_fq_name_str][subnet_name] = subnet_obj
 
             if Subnet.ip_belongs_to(IPNetwork(subnet_name),
@@ -906,7 +950,8 @@ class AddrMgmt(object):
                                     enable_dhcp=subnet_dict['enable_dhcp'],
                                     dns_nameservers=subnet_dict['dns_nameservers'],
                                     alloc_pool_list=subnet_dict['allocation_pools'],
-                                    addr_from_start = subnet_dict['addr_start'])
+                                    addr_from_start = subnet_dict['addr_start'],
+                                    should_persist=False)
                 self._subnet_objs[vn_fq_name_str][subnet_name] = subnet_obj
 
             if Subnet.ip_belongs_to(IPNetwork(subnet_name),
@@ -920,7 +965,7 @@ class AddrMgmt(object):
             subnet_obj = self._subnet_objs[vn_fq_name_str][subnet_name]
             if Subnet.ip_belongs_to(IPNetwork(subnet_name),
                                     IPAddress(ip_addr)):
-                subnet_obj.ip_free(IPAddress(ip_addr))
+                subnet_obj.ip_reset_in_use(ip_addr)
                 break
     # end ip_free_notify
 

--- a/src/config/api-server/vnc_cfg_ifmap.py
+++ b/src/config/api-server/vnc_cfg_ifmap.py
@@ -1106,7 +1106,7 @@ class VncZkClient(object):
     # end __init__
 
     def create_subnet_allocator(self, subnet, subnet_alloc_list,
-                                addr_from_start):
+                                addr_from_start, should_persist):
         # TODO handle subnet resizing change, ignore for now
         if subnet not in self._subnet_allocators:
             if addr_from_start is None:
@@ -1115,7 +1115,7 @@ class VncZkClient(object):
                 self._zk_client, self._subnet_path+'/'+subnet+'/',
                 size=0, start_idx=0, reverse=not addr_from_start,
                 alloc_list=subnet_alloc_list,
-		max_alloc=self._MAX_SUBNET_ADDR_ALLOC)
+		        max_alloc=self._MAX_SUBNET_ADDR_ALLOC)
     # end create_subnet_allocator
 
     def delete_subnet_allocator(self, subnet):
@@ -1133,16 +1133,25 @@ class VncZkClient(object):
         return allocator.read(addr)
     # end subnet_is_addr_allocated
 
-    def subnet_alloc_req(self, subnet, addr=None):
+    def subnet_set_in_use(self, subnet, addr):
+        allocator = self._get_subnet_allocator(subnet)
+        allocator.set_in_use(addr)
+    # end subnet_set_in_use
+
+    def subnet_reset_in_use(self, subnet, addr):
+        allocator = self._get_subnet_allocator(subnet)
+        allocator.reset_in_use(addr)
+    # end subnet_reset_in_use
+
+    def subnet_reserve_req(self, subnet, addr, value):
+        allocator = self._get_subnet_allocator(subnet)
+        return allocator.reserve(addr, value)
+    # end subnet_reserve_req
+
+    def subnet_alloc_req(self, subnet, value=None):
         allocator = self._get_subnet_allocator(subnet)
         try:
-            if addr is not None:
-                if allocator.read(addr) is not None:
-                    return addr
-                else:
-                    return allocator.reserve(addr)
-            else:
-                return allocator.alloc()
+            return allocator.alloc(value=value)
         except ResourceExhaustionError:
             return None
     # end subnet_alloc_req
@@ -1594,22 +1603,35 @@ class VncDbClient(object):
         return self._zk_db.subnet_is_addr_allocated(subnet, addr)
     # end subnet_is_addr_allocated
 
-    def subnet_alloc_req(self, subnet, addr=None):
-        return self._zk_db.subnet_alloc_req(subnet, addr)
+    def subnet_set_in_use(self, subnet, addr):
+        return self._zk_db.subnet_set_in_use(subnet, addr)
+    # end subnet_set_in_use
+
+    def subnet_reset_in_use(self, subnet, addr):
+        return self._zk_db.subnet_reset_in_use(subnet, addr)
+    #end subnet_reset_in_use
+
+    def subnet_alloc_req(self, subnet, value=None):
+        return self._zk_db.subnet_alloc_req(subnet, value)
     # end subnet_alloc_req
 
+    def subnet_reserve_req(self, subnet, addr=None, value=None):
+        return self._zk_db.subnet_reserve_req(subnet, addr, value)
+    # end subnet_reserve_req
+
     def subnet_free_req(self, subnet, addr):
-        self._zk_db.subnet_free_req(subnet, addr)
+        return self._zk_db.subnet_free_req(subnet, addr)
     # end subnet_free_req
 
     def subnet_create_allocator(self, subnet, subnet_alloc_list,
-                                addr_from_start):
-        self._zk_db.create_subnet_allocator(subnet, subnet_alloc_list,
-                                            addr_from_start)
+                                addr_from_start, should_persist):
+        return self._zk_db.create_subnet_allocator(subnet,
+                               subnet_alloc_list, addr_from_start,
+                               should_persist)
     # end subnet_create_allocator
 
     def subnet_delete_allocator(self, subnet):
-        self._zk_db.delete_subnet_allocator(subnet)
+        return self._zk_db.delete_subnet_allocator(subnet)
     # end subnet_delete_allocator
 
     def uuid_vnlist(self):

--- a/src/config/api-server/vnc_cfg_types.py
+++ b/src/config/api-server/vnc_cfg_types.py
@@ -98,7 +98,8 @@ class FloatingIpServer(FloatingIpServerGen):
             return (False, (403, 'Ip address already in use'))
         try:
             fip_addr = cls.addr_mgmt.ip_alloc_req(vn_fq_name,
-                                                  asked_ip_addr=req_ip)
+                                                  asked_ip_addr=req_ip,
+                                                  alloc_id=obj_dict['uuid'])
         except Exception as e:
             return (False, (500, str(e)))
         obj_dict['floating_ip_address'] = fip_addr
@@ -137,7 +138,8 @@ class FloatingIpServer(FloatingIpServerGen):
         if req_ip == None:
             return True, ""
         try:
-            cls.addr_mgmt.ip_alloc_req(vn_fq_name, asked_ip_addr=req_ip)
+            cls.addr_mgmt.ip_alloc_req(vn_fq_name, asked_ip_addr=req_ip,
+                                       alloc_id=obj_dict['uuid'])
         except Exception as e:
             return (False, (500, str(e)))
         db_conn.config_log('AddrMgmt: alloc %s FIP for vn=%s to recover DELETE failure'
@@ -230,7 +232,8 @@ class InstanceIpServer(InstanceIpServerGen):
         try:
             ip_addr = cls.addr_mgmt.ip_alloc_req(
                 vn_fq_name, vn_dict=vn_dict, sub=sub, asked_ip_addr=req_ip,
-                asked_ip_version=req_ip_version)
+                asked_ip_version=req_ip_version,
+                alloc_id=obj_dict['uuid'])
         except Exception as e:
             return (False, (500, str(e)))
         obj_dict['instance_ip_address'] = ip_addr
@@ -265,7 +268,13 @@ class InstanceIpServer(InstanceIpServerGen):
             # Ignore ip-fabric and link-local address allocations
             return True,  ""
 
-        ip_addr = obj_dict['instance_ip_address']
+        ip_addr = obj_dict.get('instance_ip_address')
+        if not ip_addr:
+            db_conn.config_log('instance_ip_address missing for object %s'
+                           % (obj_dict['uuid']),
+                           level=SandeshLevel.SYS_NOTICE)
+            return True, ""
+
         db_conn.config_log('AddrMgmt: free IP %s, vn=%s'
                            % (ip_addr, vn_fq_name),
                            level=SandeshLevel.SYS_DEBUG)
@@ -285,7 +294,8 @@ class InstanceIpServer(InstanceIpServerGen):
         if req_ip == None:
             return True, ""
         try:
-            cls.addr_mgmt.ip_alloc_req(vn_fq_name, asked_ip_addr=req_ip)
+            cls.addr_mgmt.ip_alloc_req(vn_fq_name, asked_ip_addr=req_ip,
+                                       alloc_id=obj_dict['uuid'])
         except Exception as e:
             return (False, (500, str(e)))
         db_conn.config_log('AddrMgmt: alloc %s for vn=%s to recover DELETE failure'
@@ -511,12 +521,12 @@ class VirtualNetworkServer(VirtualNetworkServerGen):
         if not ok:
             return (ok, (409, result))
 
+        db_conn.update_subnet_uuid(obj_dict)
+
         try:
             cls.addr_mgmt.net_update_req(fq_name, read_result, obj_dict, id)
         except Exception as e:
             return (False, (500, str(e)))
-
-        db_conn.update_subnet_uuid(obj_dict)
 
         (ok, error) =  cls._check_route_targets(obj_dict, db_conn)
         if not ok:
@@ -558,7 +568,8 @@ class VirtualNetworkServer(VirtualNetworkServerGen):
 
     @classmethod
     def ip_alloc(cls, vn_fq_name, subnet_name, count):
-        ip_list = [cls.addr_mgmt.ip_alloc_req(vn_fq_name, subnet_name)
+        ip_list = [cls.addr_mgmt.ip_alloc_req(vn_fq_name, subnet_name,
+                                              alloc_id='user-opaque-alloc')
                    for i in range(count)]
         msg = 'AddrMgmt: reserve %d IP for vn=%s, subnet=%s - %s' \
             % (count, vn_fq_name, subnet_name if subnet_name else '', ip_list)

--- a/src/config/common/tests/test_common.py
+++ b/src/config/common/tests/test_common.py
@@ -12,6 +12,7 @@ import testtools
 from testtools import content, content_type
 from flexmock import flexmock, Mock
 from webtest import TestApp
+import contextlib
 
 from vnc_api.vnc_api import *
 import cfgm_common.ifmap.client as ifmap_client
@@ -203,6 +204,16 @@ def setup_common_flexmock():
 
     flexmock(VncApiConfigLog, __new__=FakeApiConfigLog)
 #end setup_common_flexmock
+
+@contextlib.contextmanager
+def patch(target_obj, target_method_name, patched):
+    orig_method = getattr(target_obj, target_method_name)
+    setattr(target_obj, target_method_name, patched)
+    try:
+        yield
+    finally:
+        setattr(target_obj, target_method_name, orig_method)
+#end patch
 
 cov_handle = None
 class TestCase(testtools.TestCase, fixtures.TestWithFixtures):

--- a/src/config/common/zkclient.py
+++ b/src/config/common/zkclient.py
@@ -94,20 +94,46 @@ class IndexAllocator(object):
         return -1
     # end _get_bit_from_zk_index
 
-    def _set_in_use(self, idx):
+    def _set_in_use(self, bitnum):
         # if the index is higher than _max_alloc, do not use the bitarray, in
         # order to reduce the size of the bitarray. Otherwise, set the bit
         # corresponding to idx to 1 and extend the _in_use bitarray if needed
-        if idx > self._max_alloc:
+        if bitnum > self._max_alloc:
             return
-        if idx >= self._in_use.length():
-            temp = bitarray(idx - self._in_use.length())
+        if bitnum >= self._in_use.length():
+            temp = bitarray(bitnum - self._in_use.length())
             temp.setall(0)
             temp.append('1')
             self._in_use.extend(temp)
         else:
-            self._in_use[idx] = 1
+            self._in_use[bitnum] = 1
     # end _set_in_use
+
+    def _reset_in_use(self, bitnum):
+        # if the index is higher than _max_alloc, do not use the bitarray, in
+        # order to reduce the size of the bitarray. Otherwise, set the bit
+        # corresponding to idx to 1 and extend the _in_use bitarray if needed
+        if bitnum > self._max_alloc:
+            return
+        if bitnum >= self._in_use.length():
+            return
+        else:
+            self._in_use[bitnum] = 0
+    # end _reset_in_use
+
+    def set_in_use(self, idx):
+        bit_idx = self._get_bit_from_zk_index(idx)
+        if bit_idx < 0:
+            return
+        self._set_in_use(bit_idx)
+    # end set_in_use
+
+    def reset_in_use(self, idx):
+        bit_idx = self._get_bit_from_zk_index(idx)
+        if bit_idx < 0:
+            return
+        self._reset_in_use(bit_idx)
+    # end reset_in_use
 
     def alloc(self, value=None):
         if self._in_use.all():
@@ -140,7 +166,15 @@ class IndexAllocator(object):
             self._set_in_use(bit_idx)
             return idx
         except ResourceExistsError:
-            self._set_in_use(bit_idx) 
+            self._set_in_use(bit_idx)
+            existing_value = self.read(idx)
+            if (value == existing_value or
+                existing_value is None): # upgrade case
+                # idempotent reserve
+                return idx
+            msg = 'For index %s reserve conflicts with existing value %s.' \
+                  %(idx, existing_value)
+            self._zookeeper_client.syslog(msg, level='notice')
             return None
     # end reserve
 
@@ -248,7 +282,9 @@ class ZookeeperClient(object):
     def syslog(self, msg, *args, **kwargs):
         if not self._logger:
             return
-        self._logger.info(msg)
+        level = kwargs.get('level', 'info')
+        log_method = getattr(self._logger, level, self._logger.info)
+        log_method(msg)
     # end syslog
 
     def _zk_listener(self, state):

--- a/src/config/vnc_openstack/vnc_openstack/neutron_plugin_db.py
+++ b/src/config/vnc_openstack/vnc_openstack/neutron_plugin_db.py
@@ -3431,14 +3431,31 @@ class DBInterface(object):
     # end _create_instance_ip
 
     def _port_create_instance_ip(self, net_obj, port_obj, port_q, ip_family="v4"):
-        created_iip_ids = []
         fixed_ips = port_q.get('fixed_ips')
         if fixed_ips is None:
             return
+
+        # 1. find existing ips on port
+        # 2. add new ips on port from update body
+        # 3. delete old/stale ips on port
+        stale_ip_ids = {}
+        for iip in getattr(port_obj, 'instance_ip_back_refs', []):
+            iip_obj = self._instance_ip_read(instance_ip_id=iip['uuid'])
+            ip_addr = iip_obj.get_instance_ip_address()
+            stale_ip_ids[ip_addr] = iip['uuid']
+
+        created_iip_ids = []
         for fixed_ip in fixed_ips:
             try:
                 ip_addr = fixed_ip.get('ip_address')
                 if ip_addr is not None:
+                    try:
+                        # this ip survives to next gen
+                        del stale_ip_ids[ip_addr]
+                        continue
+                    except KeyError:
+                        pass
+
                     if (IPAddress(fixed_ip['ip_address']).version == 4):
                         ip_family="v4"
                     elif (IPAddress(fixed_ip['ip_address']).version == 6):
@@ -3453,9 +3470,8 @@ class DBInterface(object):
                     self._instance_ip_delete(instance_ip_id=iip_id)
                 raise e
 
-        for iip in getattr(port_obj, 'instance_ip_back_refs', []):
-            if iip['uuid'] not in created_iip_ids:
-                iip_obj = self._instance_ip_delete(instance_ip_id=iip['uuid'])
+        for stale_ip, stale_id in stale_ip_ids.items():
+            self._instance_ip_delete(instance_ip_id=stale_id)
     # end _port_create_instance_ip
 
     # port api handlers


### PR DESCRIPTION
IP mapping object was not syncing properly across 3 api-servers.
Because of this messed mapping object, api-servers were allocating
same IP during high concurrency.So we ensured proper sync,
after that duplicate issue not happened.

Closes-Bug: #JNT-8
